### PR TITLE
fix: typo and missing HTML and CSS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 #    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
-FROM golang:alpine3.9
+FROM golang:1-alpine
 
 # dockerizing https://github.com/knz/go-binsize-viz project
 

--- a/go-binsize-viz.sh
+++ b/go-binsize-viz.sh
@@ -82,8 +82,10 @@ generate_data_file() {
 
 copy_resources() {
 	printf "$(date "+%F %H:%M:%S") ${GREEN} %s${RESET}\n" "copy resources to ${tmpdir}"
-	cp -r ./js ${tmpdir}/app3.js
-	cp -r ./app3.js ${tmpdir}/app3.js
+	cp -r ./js ${tmpdir}/js
+	cp ./app3.js ${tmpdir}/app3.js
+	cp ./treemap.css ${tmpdir}/treemap.css
+	cp ./treemap_v3.html ${tmpdir}/treemap_v3.html
 }
 
 check_and_exist() {


### PR DESCRIPTION
- fix `cp -r ./js`
- copy missing `treemap.css`
- copy missing `treemap_v3.html`
- update base Go image
